### PR TITLE
Add text overlay source badge to each canvas

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -76,23 +76,6 @@
         #textOverlayIndicator.mixed   { background: #cce5ff; color: #004085; }
         #textOverlayIndicator.none    { background: #f8d7da; color: #721c24; }
 
-        .text-source-badge {
-            position: absolute;
-            bottom: 6px;
-            right: 8px;
-            font-size: 10px;
-            padding: 2px 6px;
-            border-radius: 3px;
-            opacity: 0.7;
-            pointer-events: none;
-            z-index: 1;
-            font-family: sans-serif;
-        }
-
-        .text-source-badge.svg     { background: #d4edda; color: #155724; }
-        .text-source-badge.derived { background: #fff3cd; color: #856404; }
-        .text-source-badge.none    { background: #f8d7da; color: #721c24; }
-
         .image-container.current {
             border-color: #0066cc;
         }
@@ -493,11 +476,7 @@ const layoutEl = document.getElementById('layout');
             scrollPanel.appendChild(container);
             containerEls.push(container);
 
-            // --- SVG text overlay + source badge ---
-            const badge = document.createElement('div');
-            badge.className = 'text-source-badge';
-            container.appendChild(badge);
-
+            // --- SVG text overlay ---
             const svgRendering = (canvas.rendering || []).find(r => r.format === 'image/svg+xml');
             if (svgRendering?.id) {
                 fetch(svgRendering.id, { cache: 'force-cache' })
@@ -511,14 +490,9 @@ const layoutEl = document.getElementById('layout');
                             svgEl.removeAttribute('height');
                             svgEl.classList.add('text-overlay');
                             container.appendChild(svgEl);
-                            badge.textContent = 'SVG';
-                            badge.classList.add('svg');
                         }
                     })
-                    .catch(() => {
-                        badge.textContent = 'no text';
-                        badge.classList.add('none');
-                    });
+                    .catch(() => {});
             } else {
                 const annoPage = canvas.annotations?.[0];
                 if (annoPage?.id) {
@@ -531,16 +505,8 @@ const layoutEl = document.getElementById('layout');
                             if (!w || !h) return;
                             const svgEl = buildSvgFromAnnotations(w, h, page.items || []);
                             container.appendChild(svgEl);
-                            badge.textContent = 'text derived';
-                            badge.classList.add('derived');
                         })
-                        .catch(() => {
-                            badge.textContent = 'no text';
-                            badge.classList.add('none');
-                        });
-                } else {
-                    badge.textContent = 'no text';
-                    badge.classList.add('none');
+                        .catch(() => {});
                 }
             }
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -64,6 +64,18 @@
             border: 2px solid transparent;
         }
 
+        #textOverlayIndicator {
+            font-size: 0.8em;
+            padding: 3px 8px;
+            border-radius: 3px;
+            display: inline-block;
+        }
+
+        #textOverlayIndicator.svg     { background: #d4edda; color: #155724; }
+        #textOverlayIndicator.derived { background: #fff3cd; color: #856404; }
+        #textOverlayIndicator.mixed   { background: #cce5ff; color: #004085; }
+        #textOverlayIndicator.none    { background: #f8d7da; color: #721c24; }
+
         .text-source-badge {
             position: absolute;
             bottom: 6px;
@@ -228,6 +240,7 @@
             </div>
             <div class="manifest-label" id="manifestLabel"></div>
             <div class="page-count" id="pageCount"></div>
+            <div id="textOverlayIndicator"></div>
         </div>
         <div class="side-panel-thumbnails">
             <div class="thumbnail-grid" id="thumbnailGrid"></div>
@@ -421,6 +434,31 @@ const layoutEl = document.getElementById('layout');
 
         const canvases = manifest.items || [];
         pageCountEl.textContent = `${canvases.length} pages`;
+
+        let svgCount = 0, derivedCount = 0;
+        for (const canvas of canvases) {
+            if ((canvas.rendering || []).some(r => r.format === 'image/svg+xml')) svgCount++;
+            else if (canvas.annotations?.[0]?.id) derivedCount++;
+        }
+        const noneCount = canvases.length - svgCount - derivedCount;
+        const indicator = document.getElementById('textOverlayIndicator');
+        if (svgCount === canvases.length) {
+            indicator.textContent = 'SVG text overlays';
+            indicator.className = 'svg';
+        } else if (derivedCount === canvases.length) {
+            indicator.textContent = 'Text derived from annotations';
+            indicator.className = 'derived';
+        } else if (noneCount === canvases.length) {
+            indicator.textContent = 'No text overlays';
+            indicator.className = 'none';
+        } else {
+            const parts = [];
+            if (svgCount)     parts.push(`${svgCount} SVG`);
+            if (derivedCount) parts.push(`${derivedCount} derived`);
+            if (noneCount)    parts.push(`${noneCount} none`);
+            indicator.textContent = parts.join(', ');
+            indicator.className = 'mixed';
+        }
 
         const containerEls = [];
         const thumbEls = [];

--- a/docs/index.html
+++ b/docs/index.html
@@ -64,6 +64,23 @@
             border: 2px solid transparent;
         }
 
+        .text-source-badge {
+            position: absolute;
+            bottom: 6px;
+            right: 8px;
+            font-size: 10px;
+            padding: 2px 6px;
+            border-radius: 3px;
+            opacity: 0.7;
+            pointer-events: none;
+            z-index: 1;
+            font-family: sans-serif;
+        }
+
+        .text-source-badge.svg     { background: #d4edda; color: #155724; }
+        .text-source-badge.derived { background: #fff3cd; color: #856404; }
+        .text-source-badge.none    { background: #f8d7da; color: #721c24; }
+
         .image-container.current {
             border-color: #0066cc;
         }
@@ -438,8 +455,11 @@ const layoutEl = document.getElementById('layout');
             scrollPanel.appendChild(container);
             containerEls.push(container);
 
-            // --- SVG text overlay ---
-            // Prefer an explicit SVG rendering; fall back to building one from annotations.
+            // --- SVG text overlay + source badge ---
+            const badge = document.createElement('div');
+            badge.className = 'text-source-badge';
+            container.appendChild(badge);
+
             const svgRendering = (canvas.rendering || []).find(r => r.format === 'image/svg+xml');
             if (svgRendering?.id) {
                 fetch(svgRendering.id, { cache: 'force-cache' })
@@ -453,24 +473,36 @@ const layoutEl = document.getElementById('layout');
                             svgEl.removeAttribute('height');
                             svgEl.classList.add('text-overlay');
                             container.appendChild(svgEl);
+                            badge.textContent = 'SVG';
+                            badge.classList.add('svg');
                         }
                     })
-                    .catch(() => {});
+                    .catch(() => {
+                        badge.textContent = 'no text';
+                        badge.classList.add('none');
+                    });
             } else {
                 const annoPage = canvas.annotations?.[0];
                 if (annoPage?.id) {
                     fetch(annoPage.id)
                         .then(r => r.ok ? r.json() : Promise.reject())
                         .then(page => {
-                            // Dimensions from partOf if present, else from the canvas itself
                             const partOf = page.partOf?.[0];
                             const w = (partOf?.type === 'Canvas' && partOf.width) ? partOf.width : canvas.width;
                             const h = (partOf?.type === 'Canvas' && partOf.height) ? partOf.height : canvas.height;
                             if (!w || !h) return;
                             const svgEl = buildSvgFromAnnotations(w, h, page.items || []);
                             container.appendChild(svgEl);
+                            badge.textContent = 'text derived';
+                            badge.classList.add('derived');
                         })
-                        .catch(() => {});
+                        .catch(() => {
+                            badge.textContent = 'no text';
+                            badge.classList.add('none');
+                        });
+                } else {
+                    badge.textContent = 'no text';
+                    badge.classList.add('none');
                 }
             }
 


### PR DESCRIPTION
## Summary

Adds a small badge in the bottom-right corner of each page indicating how its text overlay was obtained:

| Badge | Colour | Meaning |
|-------|--------|---------|
| `SVG` | Green | Loaded from an explicit `image/svg+xml` rendering on the canvas |
| `text derived` | Amber | Built client-side from the annotation page |
| `no text` | Red | Neither a rendering nor annotations available, or the fetch failed |

The badge is set at the same time the overlay resolves (or fails), so it accurately reflects the actual outcome rather than what the manifest advertises.

## Test plan

- [ ] https://iiif.wellcomecollection.org/presentation/b28047345 — should show `SVG` (green) on pages that have an explicit rendering
- [ ] https://iiif.wellcomecollection.org/presentation/b20389899 — should show `text derived` (amber) on pages with annotations but no SVG rendering
- [ ] Confirm `no text` (red) appears on any canvas lacking both

🤖 Generated with [Claude Code](https://claude.com/claude-code)